### PR TITLE
DB engine creation and connection pooling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -52,6 +52,20 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+description = "Programmatic startup/shutdown of ASGI apps."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308"},
+    {file = "asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f"},
+]
+
+[package.dependencies]
+sniffio = "*"
+
+[[package]]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
@@ -1723,4 +1737,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "47dc500f3b83d9a65593f2c521f69961dffba5cd149fbd55dfe9c8d1c7fe48b2"
+content-hash = "c8c6527e35419d75caf34c9c0ebd81d5a6369c42d0ae8ac6a9fff68e5565b0f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ python-multipart = "^0.0.6"
 sqlalchemy = {extras = ["asyncio"], version = "^2.0.25"}
 
 [tool.poetry.group.dev.dependencies]
+asgi-lifespan = "^2.1.0"
 black = "^24.1.0"
 httpx = "^0.26.0"
 isort = "^5.13.2"

--- a/rbac/seed.py
+++ b/rbac/seed.py
@@ -27,10 +27,11 @@ async def upgrade(settings: Settings):
     policies.append(["role_admin", "locations", "GET"])
     policies.append(["role_admin", "resources", "GET"])
 
-    enforcer = await get_enforcer(settings=settings)
+    async with get_engine(settings=settings) as engine:
+        enforcer = await get_enforcer(engine=engine)
 
-    await enforcer.add_named_policies("p", policies)
-    await enforcer.add_role_for_user(settings.admin_username, "role_admin")
+        await enforcer.add_named_policies("p", policies)
+        await enforcer.add_role_for_user(settings.admin_username, "role_admin")
 
 
 async def downgrade(settings: Settings):

--- a/src/poly/main.py
+++ b/src/poly/main.py
@@ -1,26 +1,59 @@
+from contextlib import asynccontextmanager
 from typing import Annotated
 
-from fastapi import Depends, FastAPI
+from fastapi import APIRouter, Depends, FastAPI
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from poly import __version__
+from poly.config import get_settings
 from poly.routers import auth, branches, locations, permissions, resources, roles, user
 from poly.services.auth import validate_access_token
 
-app = FastAPI()
-app.include_router(auth.router)
-app.include_router(branches.router)
-app.include_router(locations.router)
-app.include_router(permissions.router)
-app.include_router(resources.router)
-app.include_router(roles.router)
-app.include_router(user.router)
+router = APIRouter(tags=["root"])
 
 
-@app.get("/")
+@router.get("/")
 async def root(_: Annotated[str, Depends(validate_access_token)]):
     return {"message": "Welcome to Poly"}
 
 
-@app.get("/version")
+@router.get("/version")
 async def version():
     return {"message": __version__}
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_settings()
+    uri = (
+        f"postgresql+asyncpg://"
+        f"{settings.db_username}:{settings.db_password}@"
+        f"{settings.db_host}:{settings.db_port}/"
+        f"{settings.db_name}"
+    )
+    engine = create_async_engine("".join(uri), echo=True, echo_pool="debug")
+
+    app.state.engine = engine
+    app.state.async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    yield
+
+    await engine.dispose()
+
+
+def create_app(lifespan):
+    app = FastAPI(lifespan=lifespan)
+
+    app.include_router(auth.router)
+    app.include_router(branches.router)
+    app.include_router(locations.router)
+    app.include_router(permissions.router)
+    app.include_router(resources.router)
+    app.include_router(roles.router)
+    app.include_router(router)
+    app.include_router(user.router)
+
+    return app
+
+
+app = create_app(lifespan=lifespan)

--- a/src/poly/rbac/models.py
+++ b/src/poly/rbac/models.py
@@ -1,26 +1,20 @@
-from typing import Annotated
-
 from casbin import AsyncEnforcer, Model
 from casbin_async_sqlalchemy_adapter import Adapter
-from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncEngine
 
-from poly.config import Settings, get_rbac_models, get_settings
-from poly.db import get_engine
+from poly.config import get_rbac_models
 
 
-async def get_enforcer(
-    settings: Annotated[Settings, Depends(get_settings)]
-):  # pragma: no cover
+async def get_enforcer(engine: AsyncEngine):  # pragma: no cover
     model = Model()
     model.load_model_from_text(text=get_rbac_models())
 
     enforcer = AsyncEnforcer(model=model)
 
-    async with get_engine(settings=settings) as engine:
-        adapter = Adapter(engine=engine, warning=False)
-        await adapter.create_table()
+    adapter = Adapter(engine=engine, warning=False)
+    await adapter.create_table()
 
-        enforcer.set_adapter(adapter)
-        await enforcer.load_policy()
+    enforcer.set_adapter(adapter)
+    await enforcer.load_policy()
 
     return enforcer

--- a/src/poly/routers/branches.py
+++ b/src/poly/routers/branches.py
@@ -1,10 +1,8 @@
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from poly.db import get_session
 from poly.db.schema import BranchDetails, Branches, NewBranch
 from poly.services.branches import (
     delete_branch,
@@ -22,29 +20,34 @@ router = APIRouter(prefix="/branches", tags=["branches"])
 
 @router.get("/", response_model=Branches)
 async def get_paginated_branches(
-    session: Annotated[async_sessionmaker, Depends(get_session)],
     _: Annotated[str, Depends(check_permission)],
+    request: Request,
     id: int = 0,
     per_page: int = 10,
 ):
-    total = await get_branches_count(async_session=session)
+    total = await get_branches_count(async_session=request.app.state.async_session)
     if not total:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="There are no existing branches.",
         )
 
-    branches = await get_branches(skip_id=id, limit=per_page, async_session=session)
+    branches = await get_branches(
+        skip_id=id, limit=per_page, async_session=request.app.state.async_session
+    )
 
     return {"branches": branches, "total": total}
 
 
 @router.get("/{branch_id}", response_model=BranchDetails)
 async def get_single_branch(
+    _: Annotated[str, Depends(check_permission)],
     branch_id: int,
-    session: Annotated[async_sessionmaker, Depends(get_session)],
+    request: Request,
 ):
-    branch = await get_branch_by_id_with_location(id=branch_id, async_session=session)
+    branch = await get_branch_by_id_with_location(
+        id=branch_id, async_session=request.app.state.async_session
+    )
     if not branch:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -66,8 +69,8 @@ async def get_single_branch(
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
 async def create_new_branch(
-    session: Annotated[async_sessionmaker, Depends(get_session)],
     branch: NewBranch,
+    request: Request,
     username: Annotated[str, Depends(check_permission)],
 ):
     try:
@@ -77,7 +80,7 @@ async def create_new_branch(
             township_id=branch.township_id,
             created_by=username,
             updated_by=username,
-            async_session=session,
+            async_session=request.app.state.async_session,
         )
     except ValueError as error:
         raise HTTPException(
@@ -92,10 +95,12 @@ async def create_new_branch(
 async def update_existing_branch(
     branch: NewBranch,
     branch_id: int,
-    session: Annotated[async_sessionmaker, Depends(get_session)],
+    request: Request,
     username: Annotated[str, Depends(check_permission)],
 ):
-    saved_branch = await get_branch_by_id(id=branch_id, async_session=session)
+    saved_branch = await get_branch_by_id(
+        id=branch_id, async_session=request.app.state.async_session
+    )
     if not saved_branch:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -109,7 +114,7 @@ async def update_existing_branch(
             address=branch.address,
             township_id=branch.township_id,
             updated_by=username,
-            async_session=session,
+            async_session=request.app.state.async_session,
         )
     except ValueError as error:
         raise HTTPException(
@@ -122,17 +127,20 @@ async def update_existing_branch(
 
 @router.delete("/{branch_id}")
 async def delete_existing_branch(
-    branch_id: int,
-    session: Annotated[async_sessionmaker, Depends(get_session)],
     _: Annotated[str, Depends(check_permission)],
+    branch_id: int,
+    request: Request,
 ):
-    saved_branch = await get_branch_by_id(id=branch_id, async_session=session)
+    saved_branch = await get_branch_by_id(
+        id=branch_id, async_session=request.app.state.async_session
+    )
     if not saved_branch:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Requested branch does not exist.",
         )
 
-    await delete_branch(id=branch_id, async_session=session)
+    # TODO: update who made the change
+    await delete_branch(id=branch_id, async_session=request.app.state.async_session)
 
     return {"message": "Branch is successfully deleted."}

--- a/src/poly/routers/locations.py
+++ b/src/poly/routers/locations.py
@@ -1,9 +1,7 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from fastapi import APIRouter, Depends, Request
 
-from poly.db import get_session
 from poly.db.schema import Locations
 from poly.services.auth import validate_access_token
 from poly.services.locations import get_all_locations
@@ -13,8 +11,8 @@ router = APIRouter(prefix="/locations", tags=["locations"])
 
 @router.get("/", response_model=Locations)
 async def get_locations(
-    session: Annotated[async_sessionmaker, Depends(get_session)],
-    _: Annotated[bool, Depends(validate_access_token)],
+    _: Annotated[str, Depends(validate_access_token)],
+    request: Request,
 ):
-    states = await get_all_locations(async_session=session)
+    states = await get_all_locations(async_session=request.app.state.async_session)
     return {"states": states}

--- a/src/poly/routers/permissions.py
+++ b/src/poly/routers/permissions.py
@@ -1,10 +1,8 @@
 from typing import Annotated
 
-from casbin import AsyncEnforcer
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from poly.db.schema import Permissions
-from poly.rbac.models import get_enforcer
 from poly.services.auth import validate_access_token
 from poly.services.permissions import get_permissions_by_role
 
@@ -13,10 +11,12 @@ router = APIRouter(prefix="/permissions", tags=["permissions"])
 
 @router.get("/", response_model=Permissions)
 async def get_permissions(
-    enforcer: Annotated[AsyncEnforcer, Depends(get_enforcer)],
+    request: Request,
     username: Annotated[str, Depends(validate_access_token)],
 ):
+    enforcer = request.app.state.enforcer
+
     role = enforcer.get_filtered_named_grouping_policy("g", 0, username)[0][1]
-    permissions = get_permissions_by_role(enforcer=enforcer, role=role)
+    permissions = await get_permissions_by_role(enforcer=enforcer, role=role)
 
     return {"role": role.split("_")[1], "permissions": permissions}

--- a/src/poly/routers/resources.py
+++ b/src/poly/routers/resources.py
@@ -1,9 +1,7 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from fastapi import APIRouter, Depends, Request
 
-from poly.db import get_session
 from poly.db.schema import Resources
 from poly.services.auth import validate_access_token
 from poly.services.resources import get_all_resources
@@ -13,9 +11,9 @@ router = APIRouter(prefix="/resources", tags=["resources"])
 
 @router.get("/", response_model=Resources)
 async def get_paginated_resources(
-    session: Annotated[async_sessionmaker, Depends(get_session)],
     _: Annotated[str, Depends(validate_access_token)],
+    request: Request,
 ):
-    resources = await get_all_resources(async_session=session)
+    resources = await get_all_resources(async_session=request.app.state.async_session)
 
     return {"resources": resources}

--- a/src/poly/routers/roles.py
+++ b/src/poly/routers/roles.py
@@ -1,9 +1,7 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.ext.asyncio import async_sessionmaker
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from poly.db import get_session
 from poly.db.schema import Roles
 from poly.services.permissions import check_permission
 from poly.services.roles import get_roles, get_roles_count
@@ -13,18 +11,20 @@ router = APIRouter(prefix="/roles", tags=["roles"])
 
 @router.get("/", response_model=Roles)
 async def get_paginated_roles(
-    session: Annotated[async_sessionmaker, Depends(get_session)],
     _: Annotated[str, Depends(check_permission)],
+    request: Request,
     id: int = 0,
     per_page: int = 10,
 ):
-    total = await get_roles_count(async_session=session)
+    total = await get_roles_count(async_session=request.app.state.async_session)
     if not total:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="There are no existing roles.",
         )
 
-    roles = await get_roles(skip_id=id, limit=per_page, async_session=session)
+    roles = await get_roles(
+        skip_id=id, limit=per_page, async_session=request.app.state.async_session
+    )
 
     return {"roles": roles, "total": total}

--- a/src/poly/services/branches.py
+++ b/src/poly/services/branches.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 from asyncpg.exceptions import ForeignKeyViolationError, UniqueViolationError

--- a/src/poly/services/permissions.py
+++ b/src/poly/services/permissions.py
@@ -3,15 +3,15 @@ from typing import Annotated
 from casbin import AsyncEnforcer
 from fastapi import Depends, HTTPException, Request, status
 
-from poly.rbac.models import get_enforcer
 from poly.services.auth import validate_access_token
 
 
 async def check_permission(
     request: Request,
     username: Annotated[str, Depends(validate_access_token)],
-    enforcer: Annotated[AsyncEnforcer, Depends(get_enforcer)],
 ) -> str:
+    enforcer = request.app.state.enforcer
+
     is_allowed = enforcer.enforce(
         username, request.url.path.split("/")[1], request.method
     )
@@ -24,7 +24,7 @@ async def check_permission(
     return username
 
 
-def get_permissions_by_role(enforcer: AsyncEnforcer, role: str) -> list[dict]:
+async def get_permissions_by_role(enforcer: AsyncEnforcer, role: str) -> list[dict]:
     # Returns a list in the form of [[{role_name}, {resource}, {action}]]
     role_policies = enforcer.get_filtered_named_policy("p", 0, role)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -51,14 +51,14 @@ async def test_login(client, user):
 @pytest.mark.asyncio(scope="session")
 async def test_get_active_user(db_session, inactive_user, user):
     with pytest.raises(HTTPException) as exc_info:
-        await get_active_user("non_user", db_session)
+        await get_active_user(async_session=db_session, username="non_user")
     assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert exc_info.value.detail == "User not found"
 
     with pytest.raises(HTTPException) as exc_info:
-        await get_active_user(inactive_user.name, db_session)
+        await get_active_user(async_session=db_session, username=inactive_user.name)
     assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
     assert exc_info.value.detail == "Inactive user"
 
-    result = await get_active_user("user", db_session)
+    result = await get_active_user(async_session=db_session, username="user")
     assert result.name == user.name


### PR DESCRIPTION
## Description

- Initialized DB engine at startup and shared throughout the app
- Initialized permission enforcer at startup
- Disabled connection pool in tests setup ([related question](https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html#using-multiple-asyncio-event-loops))
- Changed how database transaction is acquired and used

## Type of change

<Please delete options that are not relevant.>

- [x] Feature change